### PR TITLE
Disable Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - '**.md'
 
 jobs:
-  test:
+  test_unixlike:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -21,18 +21,3 @@ jobs:
           tree-sitter generate
           tree-sitter test
           ./script/parse_examples.sh
-  # tree-sitter/parser-setup-action is deprecated, but
-  # so far the new tree-sitter/setup-action does not
-  # work on Windows.
-  # test_windows:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Set up repo
-  #       uses: tree-sitter/parser-setup-action@v1.2
-  #     - name: Run tests
-  #       uses: tree-sitter/parser-test-action@v1.2
-  #       with:
-  #         lint: false
-  #         test-library: false
-  #         corpus-files: |
-  #           examples/succeeding/**/*.pgn


### PR DESCRIPTION
Removing comments from older working configuration.

GitHub Actions reports:
```
Makefile:2: *** Windows is not supported.  Stop.
```
so, give up.