### PR TITLE
Correctly bump checked-in version numbers to 1.0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-pgn"
 description = "Chess PGN grammar for the tree-sitter parsing library"
-version = "1.0.6"
+version = "1.0.12"
 keywords = ["incremental", "parsing", "PGN", "chess"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/rolandwalker/tree-sitter-pgn"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.6
+VERSION := 1.0.12
 
 LANGUAGE_NAME := tree-sitter-pgn
 

--- a/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
+++ b/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: tree-sitter-pgn
-Version: 1.0.6
+Version: 1.0.12
 Summary: PGN grammar for tree-sitter
 License: BSD
 Project-URL: Homepage, https://github.com/rolandwalker/tree-sitter-pgn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-pgn",
-  "version": "1.0.6",
+  "version": "1.0.12",
   "description": "Chess PGN grammar for tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-pgn"
 description = "PGN grammar for tree-sitter"
-version = "1.0.6"
+version = "1.0.12"
 keywords = ["incremental", "parsing", "tree-sitter", "PGN", "chess"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
otherwise PyPi reports the wrong number