### PR TITLE
Understand whitespace on line before percent symbol

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -24,9 +24,10 @@ bool tree_sitter_pgn_external_scanner_scan(
     const bool *valid_symbols
 ) {
     if (valid_symbols[FULL_LINE_COMMENT_DELIMITER_BOL_ASSERTION]) {
-        // it's not really clear why we have to advance over newlines, but we do
-        // eof not really needed in this form
-        while (!lexer->eof(lexer) && (lexer->lookahead == '\n' || lexer->lookahead == '\r')) {
+        // It's not really clear from the doc why we have to advance over whitespace, but we do.
+        // eof is not really needed in this form, but does no harm.
+        while (!lexer->eof(lexer) &&
+               (lexer->lookahead == '\n' || lexer->lookahead == '\r' || lexer->lookahead == '\t' || lexer->lookahead == ' ')) {
             lexer->advance(lexer, true);
         }
         if (lexer->lookahead == '%' && lexer->get_column(lexer) == 0) {

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -161,6 +161,40 @@ Percent comments in movetext
     (result_code)))
 
 ================================================================================
+Percent comments in movetext preceded by whitespace
+================================================================================
+
+[Event "?"]
+
+1. d4 Nf6 2. c4 e6  
+% comment in movetext
+0-1
+
+--------------------------------------------------------------------------------
+
+(series_of_games
+  (game
+    (header
+      (tagpair
+        (tagpair_delimiter_open)
+        (tagpair_key)
+        (double_quote)
+        (tagpair_value_contents)
+        (double_quote)
+        (tagpair_delimiter_close)))
+    (movetext
+      (move_number)
+      (san_move)
+      (san_move)
+      (move_number)
+      (san_move)
+      (san_move)
+      (rest_of_line_comment
+        (rest_of_line_comment_delimiter_open)
+        (rest_of_line_comment_text)))
+    (result_code)))
+
+================================================================================
 Semicolon comments in movetext
 ================================================================================
 


### PR DESCRIPTION
The lexer may start on such whitespace, and it must be advanced over.