### PR TITLE
Revert to old license.text in pyproject.toml

### DIFF
--- a/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
+++ b/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
@@ -2,7 +2,7 @@ Metadata-Version: 2.4
 Name: tree-sitter-pgn
 Version: 1.2.0
 Summary: PGN grammar for tree-sitter
-License-Expression: BSD-2-Clause
+License: BSD-2-Clause
 Project-URL: Homepage, https://github.com/rolandwalker/tree-sitter-pgn
 Keywords: incremental,parsing,tree-sitter,PGN,chess
 Classifier: Intended Audience :: Developers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed"
 ]
 requires-python = ">=3.8"
-license = "BSD-2-Clause"
+license.text = "BSD-2-Clause"
 readme = "README.md"
 
 [project.urls]


### PR DESCRIPTION
based on errors from the cibuildwheel action