### PR TITLE
Pin PyPi publish action to a hash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,6 @@ jobs:
       - name: Check build artifacts
         run: ls -l dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           password: ${{secrets.PYPI_API_TOKEN}}


### PR DESCRIPTION
since "release/v1.12.4" didn't exist