### PR TITLE
Better target Python 3.9 in wheel builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-pgn"
 description = "Chess PGN grammar for the tree-sitter parsing library"
-version = "1.2.10"
+version = "1.2.11"
 keywords = ["incremental", "parsing", "PGN", "chess"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/rolandwalker/tree-sitter-pgn"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.2.10
+VERSION := 1.2.11
 
 LANGUAGE_NAME := tree-sitter-pgn
 

--- a/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
+++ b/bindings/python/tree_sitter_pgn.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: tree-sitter-pgn
-Version: 1.2.10
+Version: 1.2.11
 Summary: PGN grammar for tree-sitter
 License: BSD-2-Clause
 Project-URL: Homepage, https://github.com/rolandwalker/tree-sitter-pgn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-pgn",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Chess PGN grammar for tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-pgn"
 description = "PGN grammar for tree-sitter"
-version = "1.2.10"
+version = "1.2.11"
 keywords = ["incremental", "parsing", "tree-sitter", "PGN", "chess"]
 classifiers = [
   "Intended Audience :: Developers",
@@ -24,6 +24,14 @@ Homepage = "https://github.com/rolandwalker/tree-sitter-pgn"
 core = ["tree-sitter~=0.23.0"]
 
 [tool.cibuildwheel]
+build = [
+   "cp39-*",
+   "cp310-*",
+   "cp311-*",
+   "cp312-*",
+   "cp313-*",
+   "cp314-*",
+]
 skip = [
    "cp38-*",
    "cp314t-*",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class BdistWheel(bdist_wheel):
     def get_tag(self):
         python, abi, platform = super().get_tag()
         if python.startswith("cp"):
-            python, abi = "cp38", "abi3"
+            python, abi = "cp39", "abi3"
         return python, abi, platform
 
 
@@ -45,7 +45,7 @@ setup(
                 "/utf-8",
             ],
             define_macros=[
-                ("Py_LIMITED_API", "0x03080000"),
+                ("Py_LIMITED_API", "0x03090000"),
                 ("PY_SSIZE_T_CLEAN", None)
             ],
             include_dirs=["src"],

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -13,7 +13,7 @@
     }
   ],
   "metadata": {
-    "version": "1.2.10",
+    "version": "1.2.11",
     "license": "BSD-2-Clause",
     "description": "Chess PGN grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
 * target Python 3.9 in setup.py as well as pyproject.toml
 * explicitly include builds for 3.9 - 3.14
 * bump version to v1.2.11