### PR TITLE
fix rust build

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -19,15 +19,4 @@ fn main() {
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -22,7 +22,7 @@
 
 use tree_sitter_language::LanguageFn;
 
-extern "C" {
+unsafe extern "C" {
     fn tree_sitter_pgn() -> *const ();
 }
 


### PR DESCRIPTION
- remove unused CPP build section
- add `unsafe` to the `extern` block for Rust 2024 (https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html)